### PR TITLE
feat: Integra la fuente Newsreader, actualiza las palabras clave meta…

### DIFF
--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -18,6 +18,14 @@ const {
 <meta name="generator" content={Astro.generator} />
 <title>{title}</title>
 
+<!-- Google Fonts - Optimizado con preconnect y display=swap -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&display=swap"
+  rel="stylesheet"
+/>
+
 <link rel="canonical" href={Astro.url} />
 
 <!-- Open Graph / Facebook -->
@@ -47,7 +55,7 @@ const {
 <!-- Keywords -->
 <meta
   name="keywords"
-  content="DevOps, AWS, Python, Automatización, IaC, Terraform, CloudFormation, CI/CD, Luis Arteaga, Desarrollador Cloud"
+  content="DevOps, AWS, Python, Automatización, IaC, CloudFormation, CI/CD, Luis Arteaga, Desarrollador Cloud, Arteaga, Luis, Azure, Pipelines, Docker"
 />
 
 <link rel="icon" type="image/x-icon" href="/favicon.ico" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -322,6 +322,9 @@ import cobisLogo from "../assets/cobis.svg";
       0px 0px 40px 4px #2c39797c,
       0px 0px 60px 6px #2c39797c;
     /* Añade más sombras según sea necesario */
+    /* Reducida en móvil para mejor visualización */
+    max-width: 260px;
+    width: 100%;
   }
 
   @media (min-width: 50em) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -67,7 +67,14 @@
 	--font-system: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
 		Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 	--font-body: var(--font-system);
-	--font-brand: ui-rounded, 'SF Pro Rounded', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+	--font-newsreader: 'Newsreader Variable', serif;
+	/*
+	  Italic: 0 (normal)
+	  Optical Size: Auto
+	  Weight: 200 – 800
+	  These properties should be defined in an @font-face rule for 'Newsreader Variable'
+	  and then applied to elements using this font-family.
+	*/
 
 	/* Transitions */
 	--theme-transition: 0.2s ease-in-out;


### PR DESCRIPTION
… y ajusta el estilo de la imagen principal para móvil.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates the Newsreader font with optimized Google Fonts loading, updates meta keyword list, and reduces the hero image width on mobile.
> 
> - **Head/SEO**:
>   - Add Google Fonts preconnect and stylesheet for `Newsreader` in `src/components/MainHead.astro`.
>   - Update meta `keywords` content to include `Arteaga`, `Luis`, `Azure`, `Pipelines`, `Docker`.
> - **Styles**:
>   - Define `--font-newsreader` in `src/styles/global.css` and remove `--font-brand` variable.
> - **Homepage layout**:
>   - Adjust `.hero img` in `src/pages/index.astro` to `max-width: 260px` and `width: 100%` for mobile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72655358c5fb2d2dd06078f502b55ef756a63255. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->